### PR TITLE
Fix an issue with packed files being appended instead of overwritten

### DIFF
--- a/src/main/groovy/com/github/dzwicker/stjs/gradle/StJsPlugin.groovy
+++ b/src/main/groovy/com/github/dzwicker/stjs/gradle/StJsPlugin.groovy
@@ -102,7 +102,7 @@ public class StJsPlugin implements Plugin<Project> {
                     throw new IllegalStateException("Expected packed file is not a valid file.")
                 }
 
-                def newDest = new File("${dest.absolutePath}/${from.name}")
+                def newDest = new File("${dest.absolutePath}/${from.name}").newWriter(false)
                 newDest << from.bytes
             }
         }


### PR DESCRIPTION
This fix make sure to not append packed data to existing packed files in build folder.
