### PR TITLE
ES6 Module tasks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ ext {
     sourceCompatibility = javaVersion
     targetCompatibility = javaVersion
     slf4j_version = '1.7.2'
-    stjs_version = '3.3.1.58-mirego'
+    stjs_version = '3.3.1.61-mirego'
 }
 
 group = 'com.github.dzwicker.stjs.gradle'


### PR DESCRIPTION
Expose 2 new tasks to Babelify our modules into one big file supporting ES6 modules. The projet using the plugin still need to provide the `package.json`, `bower.json` and `.babelrc` files. These files will be auto-generated in a next iteration of the plugin.

We also stop copying inherited `packed` files, this is now unnecessary and was causing issues during APK build for Android.
